### PR TITLE
20181027pyhackにて作成したドラフトをマージ

### DIFF
--- a/about_additional_track/PITCHME.md
+++ b/about_additional_track/PITCHME.md
@@ -1,0 +1,91 @@
+# Introduction of Python Web Day
+### Plone Conf 2018 Additional track
+#### 7 November 2018
+
+---
+
+## Welcome to Plone Conf 2018!
+### Welcome to Tokyo!
+
++++
+
+### Announcement for participants
+
+# Do you know that there are Additional tracks?
+
++++
+
+### Plone Conf 2018 Additional track
+
+- At Meeting Room C (6F)
+- Schedule
+  - **7 November: Python Web Day**
+  - 8 November: DB Day
+  - 9 November: Frontend Day
+
+---
+
+# Python Web Day
+
++++
+
+### Python Web Day
+
+- 20 minutes talks about Web
+- Participants from Japan try to talk in English
+
++++
+
+### Aim of Python Web Day
+
+- Know the activities of Pythonista in Japan
+- Interact with participants from abroad and participants from Japan
+
+---
+
+# Talk List of Python Web Day
+
++++
+
+### Talk lineup
+
+In Python Web Day, there are talks about...
+
+- Django
+- Serverless Framework
+- Sphinx
+- Router
+- Machine Learning Application
+
++++
+
+### Talk Schedule (AM)
+
+At Meeting Room C (6F)
+
+- 11:40 "Build a RESTful API with Serverless Framework" (20min talk)
+- 12:30 "Building a REST API with Django and Django REST Framework" (20min talk)
+
++++
+
+### Talk Schedule (PM 1/2)
+
+At Meeting Room C (6F)
+
+- 14:10 "Powerful geographic web framework GeoDjango"
+- 14:30 "Sphinx customization for OGP support."
+
++++
+
+### Talk Schedule (PM 2/2)
+
+At Meeting Room C (6F)
+
+- 15:00 "How to make the fastest Router in Python" (20min talk)
+- 16:10 "Micro Service Architecture with Machine Learning Application" (20min talk)
+
++++
+
+### Thank you for your attention!
+### We are waiting at Meeting Room C (6F)
+[Talk List Link](https://docs.google.com/spreadsheets/d/e/2PACX-1vTFKayI7BnpYsNnBvbwr38CA-9D_jZwlOFE_716k6MGDoRTRbB5kTVg8HSKlw22hPX1_F1qH8_y6eE5/pubhtml)

--- a/about_additional_track/PITCHME.yaml
+++ b/about_additional_track/PITCHME.yaml
@@ -1,0 +1,8 @@
+# カスタムCSSファイル
+theme-override : common_assets/css/PITCHME.css
+
+#スライドのページ数表示の設定
+slide-number : true
+
+#トランジションの設定
+transition : none

--- a/about_pyweb/PITCHME.yaml
+++ b/about_pyweb/PITCHME.yaml
@@ -1,0 +1,8 @@
+# カスタムCSSファイル
+theme-override : common_assets/css/PITCHME.css
+
+#スライドのページ数表示の設定
+slide-number : true
+
+#トランジションの設定
+transition : none

--- a/common_assets/css/PITCHME.css
+++ b/common_assets/css/PITCHME.css
@@ -1,0 +1,14 @@
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+  text-transform: none;
+  word-wrap: break-word;
+}
+
+.reveal section img {
+  border: 0;
+  box-shadow: none;
+}

--- a/for_timekeep/PITCHME.md
+++ b/for_timekeep/PITCHME.md
@@ -1,0 +1,19 @@
+### for Timekeeper
+
++++
+
+# 10 minutes remaining
+
+## 50% of time has passed
+
++++
+
+# 5 minutes remaining
+
+## 75% of time has passed
+
++++
+
+# 1 minute remaining
+
+## 95% of time has passed

--- a/for_timekeep/PITCHME.yaml
+++ b/for_timekeep/PITCHME.yaml
@@ -1,0 +1,8 @@
+# カスタムCSSファイル
+theme-override : common_assets/css/PITCHME.css
+
+#スライドのページ数表示の設定
+slide-number : true
+
+#トランジションの設定
+transition : none

--- a/pyweb_lineup/PITCHME.md
+++ b/pyweb_lineup/PITCHME.md
@@ -1,5 +1,7 @@
 ### Python Web Day Talk Lineup
 
++++
+
 # Build a RESTful API with Serverless Framework
 ### Masato Nakamura
 ## Nerd Factor:

--- a/pyweb_lineup/PITCHME.md
+++ b/pyweb_lineup/PITCHME.md
@@ -1,0 +1,35 @@
+### Python Web Day Talk Lineup
+
+# Build a RESTful API with Serverless Framework
+### Masato Nakamura
+## Nerd Factor:
+
++++
+
+# Building a REST API with Django and Django REST Framework
+### Hironori Sekine
+## Nerd Factor:
+
++++
+
+# Powerful geographic web framework GeoDjango
+### Mitsuki Sugiya
+## Nerd Factor:
+
++++
+
+# Sphinx customization for OGP support.
+### Takayuki Shimizukawa
+## Nerd Factor:
+
++++
+
+# How to make the fastest Router in Python
+### Makoto Kuwata
+## Nerd Factor:
+
++++
+
+# Micro Service Architecture with Machine Learning Application
+### Masato Fujitake
+## Nerd Factor:

--- a/pyweb_lineup/PITCHME.yaml
+++ b/pyweb_lineup/PITCHME.yaml
@@ -1,0 +1,8 @@
+# カスタムCSSファイル
+theme-override : common_assets/css/PITCHME.css
+
+#スライドのページ数表示の設定
+slide-number : true
+
+#トランジションの設定
+transition : none


### PR DESCRIPTION
pyhackにて4つのスライドのドラフトを作成した。
併設イベントの説明スライドを他の併設イベントでも使えるようにするため、いったんmasterにマージする
ref: https://plonejp.slack.com/archives/CD7QV149Z/p1540209502000100

* Keynoteの後の併設イベント説明用（周知目的。趣旨を説明する。数分-5分）
* Python Web Day冒頭の説明スライド（5-10分。趣旨説明の後、ラインナップの紹介を予定）
* 休憩時間の呼び込みに使うスライド（会議室Cの次のトークが何かを示す）
* タイムキーパー用残り時間スライド（残り10分、5分、1分。紙に印刷して使ってもよい）