### PR TITLE
オープニングトーク：h2ヘッダーのフォントサイズを大きく変更

### DIFF
--- a/about_pyweb/PITCHME.md
+++ b/about_pyweb/PITCHME.md
@@ -194,7 +194,9 @@ He'll show us how to make router much faster than ever.
 ---
 
 ### 16:10 - 16:50
+<div class="title-font-size-adjustment">
 ## Micro Service Architecture with Machine Learning Application
+</div>
 ## Masato Fujitake
 
 Note:

--- a/about_pyweb/PITCHME.md
+++ b/about_pyweb/PITCHME.md
@@ -89,7 +89,7 @@ Topics of AWS Lambda, a serverless service provided by AWS, will also appear.
 ---
 
 ### 12:30 - 13:10
-## Building a REST API with Django and Django REST Framework
+## <span class="title-font-size-adjustment">Building a REST API with Django and Django REST Framework</span>
 ## Hironori Sekine
 
 Note:

--- a/about_pyweb/PITCHME.md
+++ b/about_pyweb/PITCHME.md
@@ -89,7 +89,9 @@ Topics of AWS Lambda, a serverless service provided by AWS, will also appear.
 ---
 
 ### 12:30 - 13:10
-## <span class="title-font-size-adjustment">Building a REST API with Django and Django REST Framework</span>
+<div class="title-font-size-adjustment">
+## Building a REST API with Django and Django REST Framework
+</div>
 ## Hironori Sekine
 
 Note:

--- a/common_assets/css/PITCHME.css
+++ b/common_assets/css/PITCHME.css
@@ -20,6 +20,6 @@
   z-index: -5;
 }
 
-.title-font-size-adjustment {
+.title-font-size-adjustment h2 {
   font-size: 2em;
 }

--- a/common_assets/css/PITCHME.css
+++ b/common_assets/css/PITCHME.css
@@ -19,3 +19,7 @@
   left: 0;
   z-index: -5;
 }
+
+.title-font-size-adjustment {
+  font-size: 2em;
+}


### PR DESCRIPTION
h1だと文字数が大きすぎたためにh2にしていた。
h2だとお名前と同じフォントサイズになるため、区別するために可能な限りフォントサイズを大きくした